### PR TITLE
replace coverm

### DIFF
--- a/phables/config/config.yaml
+++ b/phables/config/config.yaml
@@ -6,9 +6,10 @@ log: 'phables/phables.log'
 # Databases 
 databases:
 
-# Threads per job (will be scaled down if more than --threads)
+# Job resources for use with Snakemake profiles
+  # jobCPU will be scaled down if running locally with less than 8 threads
+  # jobMem is ignored when running locally
 resources:
-  local_threads: 8
   jobCPU: 8
   jobMem: 16000       # in Mb
 

--- a/phables/config/config.yaml
+++ b/phables/config/config.yaml
@@ -7,7 +7,10 @@ log: 'phables/phables.log'
 databases:
 
 # Threads per job (will be scaled down if more than --threads)
-threads: 8
+resources:
+  local_threads: 8
+  jobCPU: 8
+  jobMem: 16000       # in Mb
 
 # Phable parameters
 minlength: 2000

--- a/phables/workflow/envs/mapping.yaml
+++ b/phables/workflow/envs/mapping.yaml
@@ -3,5 +3,5 @@ channels:
   - bioconda
 dependencies:
   - minimap2
-  - samtools==1.15
-  - coverm
+  - samtools
+#  - coverm

--- a/phables/workflow/phables.smk
+++ b/phables/workflow/phables.smk
@@ -28,7 +28,7 @@ def targetRule(fn):
     target_rules.append(fn.__name__[2:])
     return fn
 
-localrules: all, preprocess, phables, print_stages
+localrules: all, preprocess, phables, print_stages, rpkm_coverage
 
 
 """Run stages"""

--- a/phables/workflow/rules/02_phables_preflight.smk
+++ b/phables/workflow/rules/02_phables_preflight.smk
@@ -9,7 +9,7 @@ This preflight check to confirm the database filepaths
 Setting the directory variables
 """
 
-THREADS = config['threads']
+# THREADS = config['threads']
 INPUT = config['input']
 OUTDIR = config['output']
 print(f"Output files will be saved to directory, {OUTDIR}\n")

--- a/phables/workflow/rules/genes.smk
+++ b/phables/workflow/rules/genes.smk
@@ -8,7 +8,9 @@ rule scan_smg:
         genome = EDGES_FILE,
         hmm = os.path.join(DBPATH, "marker.hmm"),
     threads:
-        THREADS
+        config["resources"]["jobCPU"]
+    resources:
+        mem_mb = config["resources"]["jobMem"]
     output:
         hmmout = os.path.join(OUTDIR, "edges.fasta.hmmout")
     params:
@@ -33,7 +35,9 @@ rule scan_phrogs:
         genome = EDGES_FILE,
         db = os.path.join(DBPATH,"phrogs_mmseqs_db","phrogs_profile_db")
     threads:
-        THREADS
+        config["resources"]["jobCPU"]
+    resources:
+        mem_mb = config["resources"]["jobMem"]
     output:
         os.path.join(OUTDIR, "phrogs_annotations.tsv")
     params:

--- a/phables/workflow/rules/mapping.smk
+++ b/phables/workflow/rules/mapping.smk
@@ -12,7 +12,9 @@ rule map_reads_to_unitigs:
         bam = os.path.join(BAM_PATH, "{sample}.bam"),
         index = os.path.join(BAM_PATH, "{sample}.bam.bai")
     threads:
-         THREADS
+        config["resources"]["jobCPU"]
+    resources:
+        mem_mb = config["resources"]["jobMem"]
     log:
         os.path.join(LOGSDIR, "{sample}_mapping.log")
     conda: 


### PR DESCRIPTION
Replaces coverm. I also added resources to the config file. Just be aware that resources in the config is multi-level and if you want to make it parseable on the command line AND mergeable with the default config you'll need to replace the config merge funcion with a recursive one. the one we use for hecatomb is:
```python
import collections.abc
def recursive_merge_config(config, overwrite_config):
    def _update(d, u):
        for (key, value) in u.items():
            if isinstance(value, collections.abc.Mapping):
                d[key] = _update(d.get(key, {}), value)
            else:
                d[key] = value
        return d
    _update(config, overwrite_config)
```